### PR TITLE
Making the github token part of the steps for installation

### DIFF
--- a/release_process.md
+++ b/release_process.md
@@ -3,10 +3,9 @@
 ### Pre-requisites
 We use [Intuit Auto](https://intuit.github.io/auto/) to automate the deployment. To install 'auto' [via brew](https://intuit.github.io/auto/docs/configuration/non-npm):
 
-* `brew tap intuit/auto https://github.com/intuit/auto`
-* `brew install auto`
-
-You will also need to create a GitHub token as indicated [here](https://intuit.github.io/auto/docs/configuration/non-npm#configuration).
+1. `brew tap intuit/auto https://github.com/intuit/auto`
+1. `brew install auto`
+1. You will also need to create a GitHub token as indicated [here](https://intuit.github.io/auto/docs/configuration/non-npm#configuration).
 
 ### To create and publish the tagged release
 * `git checkout main`


### PR DESCRIPTION
My tired brain did not see the additional text as a step.  Adding it to a numbered list so that folks will notice it more...