### PR TITLE
Renaming "work cycles" to "sprints" within the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Uptime monitoring for our applications: https://app.honeybadger.io/status_pages/
 - [Retrospectives](retros.md)
 - [Roadmap](roadmap.md)
 - [Runner Role](runner.md)
-- [Work Cycles](work_cycles.md)
+- [Sprints](sprints.md)
 
 ### Infrastructure
 

--- a/development_practice.md
+++ b/development_practice.md
@@ -4,8 +4,7 @@
 
 ### Selecting an issue
 
-Each week we either work from the [Work Cycle
-Board](https://app.zenhub.com/workspaces/rdss-workcycles-61a4f1a12a399b001730f65a/board?sprints%3Asettings=current_sprint)
+Each week we either work from the [Sprint Board](https://app.zenhub.com/workspaces/rdss-61a4f1a12a399b001730f65a/board)
 The `Sprint Backlog` column of a given board has issues ordered roughly by priority.
 Always assign yourself to an issue before to starting to work on it, and move it
 to the `in progress` column.

--- a/meetings.md
+++ b/meetings.md
@@ -1,36 +1,36 @@
 # RDSS Meetings
 
-## Work Cycle Planning Meetings
+## Sprint Planning Meetings
 
-At the end of each work cycle, the RDSS team meets to plan for an upcoming cycle. A running agenda and notes document is internally maintained by the team. Going into the meeting, there is an expectation that the team is aware of the primary focus of the work cycle to be planned, in terms of services/applications.
+At the end of each work sprint, the RDSS team meets to plan for an upcoming sprint. A running agenda and notes document is internally maintained by the team. Going into the meeting, there is an expectation that the team is aware of the primary focus of the work sprint to be planned, in terms of services/applications.
 
-At each meeting, the team works from the [RDSS Work Cycle ZenHub board](https://app.zenhub.com/workspaces/rdss-workcycles-61a4f1a12a399b001730f65a/board) together. One person, the driver, updates the board during the meeting and shares their screen.
+At each meeting, the team works from the [RDSS Sprint ZenHub board](https://app.zenhub.com/workspaces/rdss-61a4f1a12a399b001730f65a/board) together. One person, the driver, updates the board during the meeting and shares their screen.
 
-1. The driver creates a GitHub milestone for the work cycle if one has not already been created (see [Work Cycles](work_cycles.md) for more information).
+1. The driver creates a GitHub milestone for the work sprint if one has not already been created (see [Sprints](sprints.md) for more information).
 
 1. The driver creates a "Candidates" column in the board and populate it with issues to be considered.
 
 1. As issues are reviewed, the team adds information to the descriptions as needed so they are actionable, and then agrees on a GitHub estimate for each one.
 
-1. Issues with an estimate that the team will work on are moved into the "Work Cycle Backlog" column.
+1. Issues with an estimate that the team will work on are moved into the "Sprint Backlog" column.
 
-1. Review is complete when all candidate issues have been reviewed by the team, whether or not they have been scheduled for this work cycle.
+1. Review is complete when all candidate issues have been reviewed by the team, whether or not they have been scheduled for this sprint.
 
-1. Issues targeted for the upcoming work cycle are placed into the "Work Cycle Backlog" under the work cycle's GitHub milestone.
+1. Issues targeted for the upcoming sprint are placed into the "Sprint Backlog" under the sprint's GitHub milestone.
 
 1. At the end of the meeting, the "Candidates" column is deleted from the board.
 
 ### Other norms
 
-A work cycle planning meeting similar to the above-described format takes place in the same timeslot during the second week of the work cycle, to review tickets that are on the board that may warrant reorganization and address any issues that have been generated as a result of unplanned work (that is, work that came up or was escalated in priority due to needs from stakeholders, users, and/or Leadership within the last week).
+A sprint planning meeting similar to the above-described format takes place in the same timeslot during the second week of the sprint, to review tickets that are on the board that may warrant reorganization and address any issues that have been generated as a result of unplanned work (that is, work that came up or was escalated in priority due to needs from stakeholders, users, and/or Leadership within the last week).
 
 ## Daily Check-ins
 
-The RDSS Team has daily check-in meetings on weekdays, excluding Work Cycle Planning days.
+The RDSS Team has daily check-in meetings on weekdays, excluding Sprint Planning days.
 
 The goal of the meeting is to briefly check in as a group, review what everyone is currently working on, and discuss items put on the agenda based on work from the past day. A running agenda and notes document is internally kept by the team.
 
-The team views the [RDSS Work Cycle ZenHub board](https://app.zenhub.com/workspaces/rdss-workcycles-61a4f1a12a399b001730f65a/board) during the meeting, which runs as follows:
+The team views the [RDSS Sprint ZenHub board](https://app.zenhub.com/workspaces/rdss-61a4f1a12a399b001730f65a/board) during the meeting, which runs as follows:
 
 1. A Round Robin, where each team member shares their briefly shares their updates in turn, without going into too much detail but providing enough context so all team members know which tasks are being discussed.
 
@@ -40,23 +40,23 @@ The team views the [RDSS Work Cycle ZenHub board](https://app.zenhub.com/workspa
 
 The "Check-in and Coffee Chat" is a check-in immediately followed by a 30-minute informal learn-out, where team members briefly share things they learned that week in their work with the team.
 
-## Work Cycle Wrap-up
+## Sprint Wrap-up
 
-On the last day of each work cycle, the RDSS team meets for a wrap-up of the work cycle with the team and other constituents, featuring a [demo](software_demos.md) of features completed in the work cycle.
+On the last day of each sprint, the RDSS team meets for a wrap-up of the sprint with the team and other constituents, featuring a [demo](software_demos.md) of features completed in the sprint.
 
 1. The wrap-up portion is driven by an agenda that is prepopulated by attendees before the meeting, with topics of discussion, demos of work, etc.
 
-2. The meeting always begins with a review and summary of the latest work cycle in the [roadmap](roadmap.md).
+2. The meeting always begins with a review and summary of the latest sprint in the [roadmap](roadmap.md).
 
 3. The meeting is open for anyone in the Library to attend, however it is the responsibility of RDSS to specifically invite people from outside of the team to attend when there are topics specific to their goals/responsibilities.
 
-4. [Demos](software_demos.md) of software features completed during the work cycle are shown by the team during the wrap-up meeting. 
+4. [Demos](software_demos.md) of software features completed during the sprint are shown by the team during the wrap-up meeting. 
 
 ## Schedule
 
-Work cycles last for 2 weeks, starting on a Wednesday and ending on a Tuesday. The RDSS standing meetings schedule looks like this:
+Sprints last for 2 weeks, starting on a Wednesday and ending on a Tuesday. The RDSS standing meetings schedule looks like this:
 
 | Week | Wednesday                           | Thursday       | Friday                            | Monday         | Tuesday                                                  |
 | :--: | :---------------------------------- | :------------- | :-------------------------------- | :------------- | :------------------------------------------------------- |
-|  1   | Work Cycle Planning (sprint begins) | Daily Check-in | Daily Check-in and Learnings Chat | Daily Check-in | Daily Check-in                                           |
-|  2   | Mid-Sprint Planning Check-in        | Daily Check-in | Daily Check-in and Learnings Chat | Daily Check-in | Daily Check-in<br />Work Cycle Wrap-up and Retrospective |
+|  1   | Sprint Planning (sprint begins) | Daily Check-in | Daily Check-in and Learnings Chat | Daily Check-in | Daily Check-in                                           |
+|  2   | Mid-Sprint Planning Check-in        | Daily Check-in | Daily Check-in and Learnings Chat | Daily Check-in | Daily Check-in<br />Sprint Wrap-up and Retrospective |

--- a/product_owners.md
+++ b/product_owners.md
@@ -14,4 +14,4 @@ Feature refinement meetings with the PO are devoted to structured conversation a
 
 - The RDSS team and the PO discuss the tickets and work together to make them actionable, answer any questions the team has about them, and determine if they are sizable by RDSS.
 
-- Issues discussed with the PO during the meeting will be appropriately documented and labeled to indicate workflow needs, level of priority, etc, per the standards outlined in the [sprints](work_cycles.md) document.
+- Issues discussed with the PO during the meeting will be appropriately documented and labeled to indicate workflow needs, level of priority, etc, per the standards outlined in the [sprints](sprints.md) document.

--- a/runner.md
+++ b/runner.md
@@ -10,7 +10,7 @@ The runner's duties are as follows:
 * Each workday, check [Honeybadger](honeybadger.io) and [DataDog](https://app.datadoghq.com/logs?saved-view-id=2137895) for errors in RDSS applications.
 * Create a ticket for each error encountered, if one does not already exist.
 * Bring error tickets to the RDSS team's attention at check-in for prioritization.
-* If a ticket is a work-stopping issue/considered high priority and is therefore assigned to the current sprint, it receives the "unplanned work" [label](work_cycles.md) in GitHub.
+* If a ticket is a work-stopping issue/considered high priority and is therefore assigned to the current sprint, it receives the "unplanned work" [label](sprints.md) in GitHub.
 * In the ticket, include a checkbox to mark the issue resolved in Honeybadger as part of the acceptance criteria if appropriate ([example here](https://github.com/pulibrary/pdc_describe/issues/1513)).
 
 * Check the failed jobs queue for PDC Describe in production. See [details](https://github.com/pulibrary/pdc_describe/blob/main/docs/sidekiq_jobs.md)

--- a/software_demos.md
+++ b/software_demos.md
@@ -1,11 +1,11 @@
 # Software Demos 
 
-New features in our software that are completed in a given work cycle are demonstrated for attendees at that work cycle's [wrap-up meeting](meetings.md).  
+New features in our software that are completed in a given sprint are demonstrated for attendees at that [sprint wrap-up meeting](meetings.md).
 
-## Norms 
+## Norms
 
-* The team member who runs the demo rotates per work cycle.  
-* The demo leader (person running the demo) at wrap-up is elected during the work cycle planning meeting.  An alternate demo leader also elected, to run the demo in the event that the demo leader is out on the day of the wrap-up.
-* During work cycle planning, the team discusses what features are on target to be demoed once complete.
-* The "demo" [label](work_cycles.md) is applied to issues in GitHub that refer to features that are intended to be part of the wrap-up demo.
-* The demo lead or their alternate (if the demo lead is out) will run the Zenhub board during morning stand-ups during that work cycle.
+* The team member who runs the demo rotates per sprint.
+* The demo leader (person running the demo) at wrap-up is elected during the sprint planning meeting.  An alternate demo leader also elected, to run the demo in the event that the demo leader is out on the day of the wrap-up.
+* During sprint planning, the team discusses what features are on target to be demoed once complete.
+* The "demo" [label](sprints.md) is applied to issues in GitHub that refer to features that are intended to be part of the wrap-up demo.
+* The demo lead or their alternate (if the demo lead is out) will run the Zenhub board during morning stand-ups during that sprint.

--- a/sprints.md
+++ b/sprints.md
@@ -1,32 +1,32 @@
-# Work Cycles
+# Sprints
 
-The RDSS team's work is structured in 2-week cycles. These cycles begin with a cycle planning meeting, and end with a cycle wrap-up. See [Meetings](meetings.md) for information on how these meetings run.  We also have a bi-weekly retrospective meeting, see [Retrospectives](retros.md) for information on these.
+The RDSS team's work is structured in 2-week sprints. These sprints begin with a sprint planning meeting, and end with a sprint wrap-up. See [Meetings](meetings.md) for information on how these meetings run.  We also have a bi-weekly retrospective meeting, see [Retrospectives](retros.md) for information on these.
 
 ## Norms
 
-- The team uses a ZenHub board called [RDSS Work Cycle](https://app.zenhub.com/workspaces/rdss-workcycles-61a4f1a12a399b001730f65a/board) to track our work.
-- Cycles are delineated by [ZenHub Sprints](https://help.zenhub.com/support/solutions/articles/43000611544-an-introduction-to-zenhub-sprints), which include the date range of the work cycle and an emoji icon to help quickly identify separate work cycles.[1]
-- Any issue in a given work cycle must have a GitHub estimate before it is worked on. This helps us estimate how much work we'll be able to accomplish in a given work cycle, which helps us give our stakeholders more predictability around when work will be delivered.
+- The team uses a ZenHub board called [RDSS Sprint](https://app.zenhub.com/workspaces/rdss-61a4f1a12a399b001730f65a/board) to track our work.
+- Sprints are delineated by [ZenHub Sprints](https://help.zenhub.com/support/solutions/articles/43000611544-an-introduction-to-zenhub-sprints), which include the date range of the sprint and an emoji icon to help quickly identify separate sprints.[1]
+- Any issue in a given sprint must have a GitHub estimate before it is worked on. This helps us estimate how much work we'll be able to accomplish in a given sprint, which helps us give our stakeholders more predictability around when work will be delivered.
 
-## Work Cycle Meetings
+## Sprint Meetings
 
-### Work Cycle Planning
+### Sprint Planning
 
-1. Look at how many story points we accomplished in the last work cycle, and estimate how many story points we think we can accomplish in this one. We might adjust the number of story points in a sprint because someone on the team is on vacation, or because there are competing team priorities (e.g., a week with a conference or lots of meetings).
+1. Look at how many story points we accomplished in the last sprint, and estimate how many story points we think we can accomplish in this one. We might adjust the number of story points in a sprint because someone on the team is on vacation, or because there are competing team priorities (e.g., a week with a conference or lots of meetings).
 2. Add candidate tickets to the sprint.
 3. Ensure all candidate tickets are estimated.
 4. Decide as a team which tickets are highest priority. By the end of the meeting we should have a sprint board containing about two weeks worth of work, in about the right priority order.
 5. Pick an emoji for our four-weeks-out sprint.
 
-### During the Work Cycle
+### During the Sprint
 
-1. Any new tickets that must be added to the board during the work cycle (e.g., for production emergencies) gets a label of `unplanned work`. [Our goal is to keep unplanned work to a minimum.](https://www.pagerduty.com/blog/5-ways-unplanned-work-disrupting-business/)
-2. The mid-workcycle planning meeting is a chance to check our progress and reflect. Are we on track to finish what we thought we'd finish? Or do we need to adjust expectations?
+1. Any new tickets that must be added to the board during the sprint (e.g., for production emergencies) gets a label of `unplanned work`. [Our goal is to keep unplanned work to a minimum.](https://www.pagerduty.com/blog/5-ways-unplanned-work-disrupting-business/)
+2. The mid-sprint planning meeting is a chance to check our progress and reflect. Are we on track to finish what we thought we'd finish? Or do we need to adjust expectations?
 
-### Work Cycle Wrap-up
+### Sprint Wrap-up
 
 1. We close out any tickets that can be closed. If any tickets are still open, we decide whether to move them to the next sprint.
-2. We record how many story points we completed in this work cycle and how many of them were unplanned work.
+2. We record how many story points we completed in this sprint and how many of them were unplanned work.
 3. We close the sprint and get ready to start the next one.
 
 ## Labels
@@ -51,7 +51,7 @@ When we add a ticket to a sprint, but then have to remove it, we add the deferre
 
 ![](images/unplanned_work.png)
 
-Any ticket that was not on the board at the start of the work cycle that has to be added later counts as unplanned work. Tracking unplanned work is a DevOps best practice: The more unplanned work, the less time exists to create and deliver intentionally prioritized work. Bringing visibility to and measuring unplanned work helps to reduce risk and improve performance.
+Any ticket that was not on the board at the start of the sprint that has to be added later counts as unplanned work. Tracking unplanned work is a DevOps best practice: The more unplanned work, the less time exists to create and deliver intentionally prioritized work. Bringing visibility to and measuring unplanned work helps to reduce risk and improve performance.
 
 ![](images/subject-heading-changes.png)
 ![](images/dataspace_label.png)


### PR DESCRIPTION
Resolves #204 